### PR TITLE
LazyLoad has been ignored since 2.14.0, use LazyData instead.

### DIFF
--- a/enveomics.R/DESCRIPTION
+++ b/enveomics.R/DESCRIPTION
@@ -26,6 +26,6 @@ Suggests:
    gplots,
    optparse
 License: Artistic-2.0
-LazyLoad: yes
+LazyData: yes
 Encoding: UTF-8
 RoxygenNote: 6.1.1


### PR DESCRIPTION
As per my email on r-package-devel.